### PR TITLE
fix: Complete naming consistency from Devil to Daem0n

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,7 +24,7 @@ build/
 
 # Project specific
 .env
-.devilmcp/
+.daem0nmcp/
 storage/
 *.db
 *.log

--- a/.env.example
+++ b/.env.example
@@ -1,26 +1,26 @@
-# DevilMCP Server Configuration
+# Daem0nMCP Server Configuration
 # Copy this file to .env and customize as needed
-# All settings use the DEVILMCP_ prefix
+# All settings use the DAEM0NMCP_ prefix
 
 # Server Port
-DEVILMCP_PORT=8080
+DAEM0NMCP_PORT=8080
 
 # Logging Level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
-DEVILMCP_LOG_LEVEL=INFO
+DAEM0NMCP_LOG_LEVEL=INFO
 
 # Storage Path for data persistence
-# Leave empty to use automatic project-specific storage (.devilmcp/storage in project root)
+# Leave empty to use automatic project-specific storage (.daem0nmcp/storage in project root)
 # Set to absolute path to override automatic detection
-DEVILMCP_STORAGE_PATH=
+DAEM0NMCP_STORAGE_PATH=
 
 # Project Root (optional - auto-detected from current working directory if not set)
-# DEVILMCP_PROJECT_ROOT=/path/to/your/project
+# DAEM0NMCP_PROJECT_ROOT=/path/to/your/project
 
 # Default command timeout in milliseconds
-DEVILMCP_DEFAULT_COMMAND_TIMEOUT=30000
+DAEM0NMCP_DEFAULT_COMMAND_TIMEOUT=30000
 
 # Default init timeout in milliseconds
-DEVILMCP_DEFAULT_INIT_TIMEOUT=10000
+DAEM0NMCP_DEFAULT_INIT_TIMEOUT=10000
 
-# Auto-run Alembic migrations on startup (true/false)
-DEVILMCP_AUTO_MIGRATE=true
+# Auto-run migrations on startup (true/false)
+DAEM0NMCP_AUTO_MIGRATE=true

--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,7 @@ logs/
 
 # Avoid re-adding
 /nul
-.devilmcp/
+.daem0nmcp/
 
 # Worktrees
 .worktrees/

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,20 +16,20 @@ COPY . .
 RUN pip install --no-cache-dir -e .
 
 # Create non-root user for security
-RUN useradd -m -u 1000 devilmcp && \
-    chown -R devilmcp:devilmcp /app
-USER devilmcp
+RUN useradd -m -u 1000 daem0nmcp && \
+    chown -R daem0nmcp:daem0nmcp /app
+USER daem0nmcp
 
 # Create data directory
-RUN mkdir -p /home/devilmcp/data
+RUN mkdir -p /home/daem0nmcp/data
 
 # Environment
-ENV DEVILMCP_STORAGE_PATH=/home/devilmcp/data
-ENV DEVILMCP_LOG_LEVEL=INFO
+ENV DAEM0NMCP_STORAGE_PATH=/home/daem0nmcp/data
+ENV DAEM0NMCP_LOG_LEVEL=INFO
 ENV PYTHONUNBUFFERED=1
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s \
-    CMD python -c "import devilmcp" || exit 1
+    CMD python -c "import daem0nmcp" || exit 1
 
-ENTRYPOINT ["python", "-m", "devilmcp.server"]
+ENTRYPOINT ["python", "-m", "daem0nmcp.server"]

--- a/daem0nmcp/__init__.py
+++ b/daem0nmcp/__init__.py
@@ -1,3 +1,3 @@
 """
-DevilMCP Core Package
+Daem0nMCP Core Package
 """

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,24 @@
 version: '3.8'
 
 services:
-  devilmcp:
+  daem0nmcp:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: devilmcp
+    container_name: daem0nmcp
     volumes:
       # Persistent storage for database
-      - devilmcp-data:/home/devilmcp/data
+      - daem0nmcp-data:/home/daem0nmcp/data
       # Mount user's project read-only for analysis
       - ${PROJECT_PATH:-.}:/workspace:ro
     environment:
-      - DEVILMCP_PROJECT_ROOT=/workspace
-      - DEVILMCP_LOG_LEVEL=${LOG_LEVEL:-INFO}
+      - DAEM0NMCP_PROJECT_ROOT=/workspace
+      - DAEM0NMCP_LOG_LEVEL=${LOG_LEVEL:-INFO}
     # Required for MCP stdio transport
     stdin_open: true
     tty: true
     restart: unless-stopped
 
 volumes:
-  devilmcp-data:
+  daem0nmcp-data:
     driver: local

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,10 +2,10 @@
 set -e
 
 # Run migrations if enabled
-if [ "$DEVILMCP_AUTO_MIGRATE" != "false" ]; then
+if [ "$DAEM0NMCP_AUTO_MIGRATE" != "false" ]; then
     echo "Running database migrations..."
-    python -c "from devilmcp.database import run_migrations; from devilmcp.config import settings; run_migrations(settings.get_database_url())"
+    python -c "from daem0nmcp.database import run_migrations; from daem0nmcp.config import settings; run_migrations(settings.get_database_url())"
 fi
 
 # Start server
-exec python -m devilmcp.server "$@"
+exec python -m daem0nmcp.server "$@"

--- a/scripts/migrate_to_v2.py
+++ b/scripts/migrate_to_v2.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Migration script: Convert old DevilMCP database to new simplified schema.
+Migration script: Convert old Daem0nMCP database to new simplified schema.
 
 This script migrates data from the old schema (13 tables) to the new schema (3 tables):
 - decisions -> memories (category='decision')
@@ -9,7 +9,7 @@ This script migrates data from the old schema (13 tables) to the new schema (3 t
 - changes with issues -> memories (category='warning')
 
 Usage:
-    python scripts/migrate_to_v2.py /path/to/project/.devilmcp/storage/devilmcp.db
+    python scripts/migrate_to_v2.py /path/to/project/.daem0nmcp/storage/daem0nmcp.db
 
 Or to migrate the current project:
     python scripts/migrate_to_v2.py
@@ -370,9 +370,9 @@ def main():
         # Try to find database in current project
         from pathlib import Path
         cwd = Path.cwd()
-        db_path = cwd / ".devilmcp" / "storage" / "devilmcp.db"
+        db_path = cwd / ".daem0nmcp" / "storage" / "daem0nmcp.db"
         if not db_path.exists():
-            print("Usage: python scripts/migrate_to_v2.py /path/to/devilmcp.db")
+            print("Usage: python scripts/migrate_to_v2.py /path/to/daem0nmcp.db")
             print(f"       Or run from project root (checked: {db_path})")
             sys.exit(1)
 


### PR DESCRIPTION
Address review feedback about naming inconsistencies.

Updates:
- Dockerfile: daem0nmcp user, DAEM0NMCP_ env vars, daem0nmcp imports
- docker-compose.yml: daem0nmcp service/container/volume names
- .env.example: DAEM0NMCP_ prefix throughout
- docker/entrypoint.sh: DAEM0NMCP_ env var and daem0nmcp imports
- scripts/migrate_to_v2.py: .daem0nmcp paths
- .gitignore and .dockerignore: .daem0nmcp directory
- daem0nmcp/__init__.py: docstring updated

All 88 tests passing.