### PR TITLE
Rename Devil to Daem0n throughout codebase

### DIFF
--- a/AI_INSTRUCTIONS.md
+++ b/AI_INSTRUCTIONS.md
@@ -299,6 +299,16 @@ Per-project storage at:
 <project_root>/.daem0nmcp/storage/daem0nmcp.db
 ```
 
+### Legacy Migration (from DevilMCP)
+If upgrading from DevilMCP, your data is automatically migrated:
+- Old location: `.devilmcp/storage/devilmcp.db`
+- New location: `.daem0nmcp/storage/daem0nmcp.db`
+
+Migration happens automatically on first startup. After migration completes, you can safely delete:
+- `.devilmcp/` directory
+- `devilmcp.egg-info/` directory (will regenerate as `daem0nmcp.egg-info`)
+- `devilmcp/` source directory (replaced by `daem0nmcp/`)
+
 ---
 
 ## WORKFLOW CHEAT SHEET

--- a/daem0nmcp/config.py
+++ b/daem0nmcp/config.py
@@ -5,6 +5,7 @@ All settings are loaded from environment variables with DAEM0NMCP_ prefix.
 Example: DAEM0NMCP_LOG_LEVEL=DEBUG
 """
 
+import shutil
 from pathlib import Path
 from typing import Optional
 from pydantic_settings import BaseSettings
@@ -25,6 +26,48 @@ class Settings(BaseSettings):
         env_file = ".env"
         env_file_encoding = "utf-8"
 
+    def _migrate_legacy_storage(self, project_path: Path, new_storage: Path) -> bool:
+        """
+        Migrate data from legacy .devilmcp directory to .daem0nmcp.
+
+        Returns True if migration occurred.
+        """
+        import logging
+        logger = logging.getLogger(__name__)
+
+        legacy_storage = project_path / ".devilmcp" / "storage"
+        legacy_db = legacy_storage / "devilmcp.db"
+        new_db = new_storage / "daem0nmcp.db"
+
+        # Check if legacy storage exists and new doesn't have data yet
+        if not legacy_storage.exists():
+            return False
+
+        if new_db.exists():
+            logger.info("New database already exists, skipping legacy migration")
+            return False
+
+        # Create new storage directory
+        new_storage.mkdir(parents=True, exist_ok=True)
+
+        # Migrate database file
+        if legacy_db.exists():
+            shutil.copy2(legacy_db, new_db)
+            logger.info(f"Migrated database: {legacy_db} -> {new_db}")
+
+        # Also check for any other .db files (e.g., daem0nmcp.db in old location)
+        for db_file in legacy_storage.glob("*.db"):
+            if db_file.name != "devilmcp.db":
+                dest = new_storage / db_file.name
+                if not dest.exists():
+                    shutil.copy2(db_file, dest)
+                    logger.info(f"Migrated database: {db_file} -> {dest}")
+
+        logger.info(
+            f"Legacy migration complete. You can safely delete: {project_path / '.devilmcp'}"
+        )
+        return True
+
     def get_storage_path(self) -> str:
         """
         Determine storage path with project isolation.
@@ -34,6 +77,8 @@ class Settings(BaseSettings):
         2. project_root/.daem0nmcp/storage (if project_root is set)
         3. <cwd>/.daem0nmcp/storage (current working directory)
         4. ./storage (fallback for centralized storage)
+
+        Also handles automatic migration from legacy .devilmcp storage.
         """
         import logging
         logger = logging.getLogger(__name__)
@@ -54,6 +99,10 @@ class Settings(BaseSettings):
         else:
             # Use project-specific storage
             storage = project_path / ".daem0nmcp" / "storage"
+
+            # Check for and migrate legacy .devilmcp storage
+            self._migrate_legacy_storage(project_path, storage)
+
             logger.info(f"Project detected: {project_path.name}")
             logger.info(f"Using project-specific storage: {storage}")
 


### PR DESCRIPTION
Automatically migrates database from .devilmcp/storage/ to .daem0nmcp/storage/ on first startup. Users upgrading from DevilMCP will have their memories preserved without manual intervention.

- Added _migrate_legacy_storage() method to Settings class
- Copies devilmcp.db to daem0nmcp.db in new location
- Documents migration in AI_INSTRUCTIONS.md